### PR TITLE
Replaced autoloading system

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
     "issues": "https://github.com/PhpMetrics/DesignPatternDetector/issues"
   },
   "autoload": {
-    "psr-0": {
-      "Hal\\": "./src/"
+    "psr-4": {
+      "Hal\\": "./src/Hal/"
     }
   },
   "require": {


### PR DESCRIPTION
As of 2014-10-21 PSR-0 has been marked as deprecated. PSR-4 is now recommended as an alternative.
