### PR TITLE
Fix error Missing argument 1 for Symfony\Component\Console\Output\Out…

### DIFF
--- a/src/Hal/Application/Command/RunPatternCommand.php
+++ b/src/Hal/Application/Command/RunPatternCommand.php
@@ -123,7 +123,6 @@ class RunPatternCommand extends Command
 
         // inform user
         $output->writeln(sprintf("<info>Found %d design patterns</info>", sizeof($patterns)));
-        $output->writeln();
 
 
         foreach($patterns as $pattern) {


### PR DESCRIPTION
Hello @Halleck45,

PR Fix missing argument for writeln in RunPatternCommand.

Try joke :-)
